### PR TITLE
Make ProjectId configurable

### DIFF
--- a/src/Fursvp.Communication/SendGridOptions.cs
+++ b/src/Fursvp.Communication/SendGridOptions.cs
@@ -11,9 +11,9 @@ namespace Fursvp.Communication
     public class SendGridOptions
     {
         /// <summary>
-        /// The value "SendGrid".
+        /// Specifies the portion of env file to import
         /// </summary>
-        public const string SendGrid = "SendGrid";
+        public const string SectionName = "SendGrid";
 
         /// <summary>
         /// Gets or sets the SendGrid API key.

--- a/src/fursvp.api/Startup.cs
+++ b/src/fursvp.api/Startup.cs
@@ -10,6 +10,7 @@ namespace Fursvp.Api
     using Fursvp.Api.Filters;
     using Fursvp.Api.Responses;
     using Fursvp.Communication;
+    using Fursvp.Data.Firestore;
     using Fursvp.Domain.Authorization;
     using Fursvp.Domain.Authorization.ReadAuthorization;
     using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -61,6 +62,7 @@ namespace Fursvp.Api
             });
 
             services.AddDomainServices();
+            services.Configure<FirestoreOptions>(Configuration.GetSection(FirestoreOptions.SectionName));
             services.AddFursvpDataWithFirestore();
 
             if (Environment.IsDevelopment() || string.IsNullOrEmpty(Configuration["SendGrid:ApiKey"]))
@@ -70,7 +72,7 @@ namespace Fursvp.Api
             else
             {
                 services.AddSingleton<IEmailer, SendGridEmailer>();
-                services.Configure<SendGridOptions>(Configuration.GetSection(SendGridOptions.SendGrid));
+                services.Configure<SendGridOptions>(Configuration.GetSection(SendGridOptions.SectionName));
             }
 
             services.AddLogging(lc =>

--- a/src/fursvp.api/settings.env
+++ b/src/fursvp.api/settings.env
@@ -2,3 +2,4 @@ GOOGLE_APPLICATION_CREDENTIALS=/root/.microsoft/usersecrets/fursvp/firestore.jso
 Kestrel:Certificates:Development:Password=xxxxx
 SendGrid:ApiKey=
 AuthorizationIssuerSigningKey=00000000-0000-0000-0000-000000000000
+Firestore:ProjectId=

--- a/src/fursvp.data/Firestore/FirestoreOptions.cs
+++ b/src/fursvp.data/Firestore/FirestoreOptions.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="FirestoreOptions.cs" company="skippyfox">
+// Copyright (c) skippyfox. All rights reserved.
+// Licensed under the MIT license. See the license.md file in the project root for full license information.
+// </copyright>
+
+namespace Fursvp.Data.Firestore
+{
+    /// <summary>
+    /// A collection of configuration options for use with the <see cref="FirestoreRepository{T}"/>.
+    /// </summary>
+    public class FirestoreOptions
+    {
+        /// <summary>
+        /// Specifies the portion of env file to import
+        /// </summary>
+        public const string SectionName = "Firestore";
+
+        /// <summary>
+        /// Gets or sets the Google Cloud ProjectId for Firebase
+        /// </summary>
+        public string ProjectId { get; set; }
+    }
+}
+
+
+
+

--- a/src/fursvp.data/Firestore/FirestoreRepository.cs
+++ b/src/fursvp.data/Firestore/FirestoreRepository.cs
@@ -10,6 +10,7 @@ namespace Fursvp.Data.Firestore
     using System.Threading.Tasks;
     using Fursvp.Domain;
     using Google.Cloud.Firestore;
+    using Microsoft.Extensions.Options;
 
     /// <summary>
     /// Interfaces with Google Firestore to access documents representing a domain entity.
@@ -18,15 +19,19 @@ namespace Fursvp.Data.Firestore
     public class FirestoreRepository<T> : IRepository<T>
         where T : IEntity<T>
     {
-        private const string ProjectId = "fursvp-dev"; // TODO - put into config variable
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FirestoreRepository{T}"/> class.
         /// </summary>
         /// <param name="mapper">An instance of <see cref="IDictionaryMapper{T}"/> to map between the domain entity and the Firestore document.</param>
-        public FirestoreRepository(IDictionaryMapper<T> mapper)
+        public FirestoreRepository(IOptions<FirestoreOptions> options, IDictionaryMapper<T> mapper)
         {
-            Db = FirestoreDb.Create(ProjectId);
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            Db = FirestoreDb.Create(options.Value.ProjectId);
             Collection = Db.Collection(typeof(T).Name);
             Mapper = mapper;
         }


### PR DESCRIPTION
Also renamed SendGridOptions.SendGrid => SendGridOptions.SectionName to create shared terminology with FirestoreOptions.